### PR TITLE
Fix CLI11 missing linking, compile flags and clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,59 +80,53 @@ include_directories(${protobuf_SOURCE_DIR}/src)
 
 # Start flags
 
-if (CMAKE_CXX_COMPILER)
-    add_compile_options(
-        # -Werror
-        # -Wall
-        # -Wextra
-        # -Wpedantic
+function(apply_compile_flags target)
+    if (CMAKE_CXX_COMPILER)
+        target_compile_options(${target} PRIVATE
+            -Werror
+            -Wall
+            -Wextra
+            -Wpedantic
 
-        # -Wcast-align
-        # -Wcast-qual
-        # -Wconversion
-        # -Wctor-dtor-privacy
-        # -Wenum-compare
-        # -Wfloat-equal
-        # -Wnon-virtual-dtor
-        # -Wold-style-cast
-        # -Woverloaded-virtual
-        # -Wredundant-decls
-        # -Wsign-conversion
-        # -Wsign-promo
-        # -Wzero-as-null-pointer-constant  !!!TODO!!! to come up with a solution: how to compile project with flags, but do not compile dependeces with it.
-
-        -O3
-        -ffast-math
-    )
-endif()
+            -Wcast-align
+            -Wcast-qual
+            -Wconversion
+            -Wctor-dtor-privacy
+            -Wenum-compare
+            -Wfloat-equal
+            -Wnon-virtual-dtor
+            -Wold-style-cast
+            -Woverloaded-virtual
+            -Wredundant-decls
+            -Wsign-conversion
+            -Wsign-promo
+            -Wzero-as-null-pointer-constant
+            
+            -O3
+            -ffast-math
+        )
+    endif()
+endfunction()
 
 # End flags
 
-
-# Start  clang-tidy
+# Start clang-tidy
 
 find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
 
-# !!!TODO!!! Make clang tidy great again
+ if(NOT CLANG_TIDY_COMMAND)
+     message(FATAL_ERROR "Clang-tidy is not found!")
+ else()
+     message(STATUS "Clang-tidy is ON")
 
-# if(NOT CLANG_TIDY_COMMAND)
-#     message(FATAL_ERROR "Clang-tidy is not found!")
-# else()
-#     message(STATUS "Clang-tidy is ON")
+     # Google C++ Style
+     set(CLANGTIDY_EXTRA_ARGS
+         "-checks=google-*"
+         "-warnings-as-errors=*"
+     )
 
-#     # Google C++ Style
-#     set(CLANGTIDY_EXTRA_ARGS
-#         "-checks=google-*"
-#         "-warnings-as-errors=*"
-#     )
-
-#     set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};-p=${CMAKE_BINARY_DIR};${CLANGTIDY_EXTRA_ARGS}" CACHE STRING "" FORCE)
-
-#     set(IGNORE_CLANG_TIDY_FILES
-#         "*.pb.h"
-#         "*.pb.cc"
-#     )
-# endif()
+     set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};-p=${CMAKE_BINARY_DIR};${CLANGTIDY_EXTRA_ARGS}" CACHE STRING "" FORCE)
+ endif()
 
 # End clang-tidy
 
@@ -149,4 +143,3 @@ if(NOT MYLIB_TESTING)
 else()
     enable_testing()
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,16 +47,17 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cli11)
 # </Cli11>
 
-# <GTEst>
+# <GTest>
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG        release-1.12.1
 )
 
-set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
-# </GTEst>
+# </GTest>
 
 # <Protobuf>
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)

--- a/dasboot/cli/CMakeLists.txt
+++ b/dasboot/cli/CMakeLists.txt
@@ -3,8 +3,7 @@
 set(SOURCES cli.cpp)
 set(HEADERS cli.hpp)
 add_library(cli ${SOURCES} ${HEADERS})
-target_include_directories(cli PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
+target_link_libraries(cli PUBLIC CLI11::CLI11)
 
 # tests:
 

--- a/dasboot/cli/CMakeLists.txt
+++ b/dasboot/cli/CMakeLists.txt
@@ -3,11 +3,13 @@
 set(SOURCES cli.cpp)
 set(HEADERS cli.hpp)
 add_library(cli ${SOURCES} ${HEADERS})
+apply_compile_flags(cli)
 target_link_libraries(cli PUBLIC CLI11::CLI11)
 
 # tests:
 
 add_executable(cli_ut cli_ut.cpp)
+apply_compile_flags(cli_ut)
 
 target_link_libraries(
     cli_ut

--- a/dasboot/controller/CMakeLists.txt
+++ b/dasboot/controller/CMakeLists.txt
@@ -3,12 +3,14 @@
 set(SOURCES controller.cpp)
 set(HEADERS controller.hpp)
 add_library(controller ${SOURCES} ${HEADERS})
+apply_compile_flags(controller)
 target_link_libraries(controller PUBLIC ProtobufMessages)
 add_dependencies(controller ProtobufMessages)
 
 # tests:
 
 add_executable(controller_ut controller_ut.cpp)
+apply_compile_flags(controller_ut)
 
 target_link_libraries(
     controller_ut

--- a/dasboot/proto/CMakeLists.txt
+++ b/dasboot/proto/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Set paths for proto files
 
-
-
 set(PROTO_FILES_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(GENERATED_PROTO_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${GENERATED_PROTO_SRC_DIR})
@@ -29,5 +27,7 @@ foreach(proto_file ${PROTO_FILES})
 endforeach()
 
 add_library(ProtobufMessages STATIC ${GENERATED_PROTO_SRCS} ${GENERATED_PROTO_HDRS})
+set_target_properties(ProtobufMessages PROPERTIES CXX_CLANG_TIDY "")
 target_link_libraries(ProtobufMessages PRIVATE protobuf::libprotobuf)
-target_include_directories(ProtobufMessages PUBLIC ${GENERATED_PROTO_SRC_DIR})
+# SYSTEM here is required cause we do not want -Werror to be applied to protobuf headers
+target_include_directories(ProtobufMessages SYSTEM PUBLIC ${GENERATED_PROTO_SRC_DIR})


### PR DESCRIPTION
Fixed an error occurring when CLI11 is not installed on system in 42b1767 - now it links it from ```_deps```  directory we fetch. 