### PR TITLE
 Remove obselete Controller structs

### DIFF
--- a/dasboot/controller/controller.cpp
+++ b/dasboot/controller/controller.cpp
@@ -1,48 +1,4 @@
 #include <dasboot/controller/controller.hpp>
 
 namespace NController {
-
-    TReferencingRule::TReferencingRule(const string& reference, const bool isReferencingById) {
-        Reference = reference;
-        IsReferencingById = isReferencingById;
-    }
-
-    TStartSettings::TStartSettings(const TReferencingRule& container) {
-        Container = container;
-    }
-
-    TStopSettings::TStopSettings(const TReferencingRule&  container) {
-        Container = container;
-    }
-
-    TRemoveSettings::TRemoveSettings(const TReferencingRule& container) {
-        Container = container;
-    }
-
-    TExecuteSettings::TExecuteSettings(const TReferencingRule& container, 
-    const string& command, const string& args, const bool backgroundFlag) {
-        Container = container;
-        Command = command;
-        Args = args;
-        BackgroundFlag = backgroundFlag;
-    }
-
-    TController::TController() {
-        globalConfig = TGlobalConfig();
-    }
-
-    TRequest TController::Build(const TBuildSettings& buildSettings) {
-        TRequest request;
-        request.set_type("build");
-
-        TArg* arg1 = request.add_args();
-        arg1->set_name("PathToDasbootFile");
-        arg1->set_value(buildSettings.PathToDasbootFile);
-
-        TArg* arg2 = request.add_args();
-        arg2->set_name("ContainerName");
-        arg2->set_value(buildSettings.ContainerName.value_or(std::to_string(rand())));
-
-        return request;
-    }
 } // namespace NController

--- a/dasboot/controller/controller.hpp
+++ b/dasboot/controller/controller.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <optional>
 #include <stdlib.h>
@@ -14,52 +15,8 @@ namespace NController {
     using NMessages::TResponse;
 
     using std::string;
-    using std::optional;
 
-    /* All of these used for request construction: */
-    struct TReferencingRule {
-        string Reference;
-        bool IsReferencingById;
-
-        TReferencingRule(const string& reference = NULL, const bool isReferencingById = true);
-    };
-
-    struct TBuildSettings {
-        string PathToDasbootFile;
-
-        optional<string> ContainerName;
-    };
-
-    struct TStartSettings {
-        TReferencingRule Container;
-
-        TStartSettings(const TReferencingRule& container);
-    };
-
-    struct TStopSettings {
-        TReferencingRule Container;
-
-        TStopSettings(const TReferencingRule&  container);
-    };
-
-    struct TRemoveSettings {
-        TReferencingRule Container;
-
-        TRemoveSettings(const TReferencingRule& container);
-    };
-
-    struct TExecuteSettings {
-        TReferencingRule Container;
-        string Command;
-        string Args;
-        bool BackgroundFlag;
-
-        TExecuteSettings(const TReferencingRule& container, const string& command, const string& args, const bool backgroundFlag);
-    };
-
-    struct TListSettings {
-        bool ShowAllFlag;
-    };
+    /* TODO: USE PROTOBUF MESSAGES HERE */
 
     /* Used for default configurations retrievment: */
     class TGlobalConfig final {
@@ -71,11 +28,11 @@ namespace NController {
 
     class TController final {
         private:
-            TGlobalConfig globalConfig;
-            TZeroMQSocket daemonSocket;
+            const TGlobalConfig GlobalConfig;
+            TZeroMQSocket DaemonSocket;
 
         public:
-            TController();
+            TController(TGlobalConfig& globalConfig) : GlobalConfig(globalConfig) {};
 
             bool WriteToDaemon();
             bool ReadFromDaemon();
@@ -87,15 +44,15 @@ namespace NController {
             bool CommandHelp(const std::string command);
 
             // These work with Daemon:
-            TRequest Build(const TBuildSettings& buildSettings);
+            TRequest Build();
 
-            bool Start(const TStartSettings& startSettings);
+            bool Start();
 
-            bool Stop(const TStopSettings& stopSettings);
-            bool Remove(const TRemoveSettings& removeSettings);
+            bool Stop();
+            bool Remove();
 
-            bool Execute(const TExecuteSettings& executeSettings);
+            bool Execute();
 
-            bool List(const TListSettings& listSettings);
+            bool List();
     };
 };

--- a/dasboot/controller/controller_ut.cpp
+++ b/dasboot/controller/controller_ut.cpp
@@ -2,30 +2,6 @@
 
 #include <dasboot/controller/controller.hpp>
 
-TEST(ControllerUt, BuildContainerRequest) {
-    NController::TController controller;
-    NController::TBuildSettings buildSettings;
-    buildSettings.PathToDasbootFile = "path/to/dasbootfile";
-    buildSettings.ContainerName = "Test";
-
-    NController::TRequest expectedRequest;
-    expectedRequest.set_type("build");
-    NController::TArg* arg1 = expectedRequest.add_args();
-    arg1->set_name("PathToDasbootFile");
-    arg1->set_value(buildSettings.PathToDasbootFile);
-
-    NController::TArg* arg2 = expectedRequest.add_args();
-    arg2->set_name("ContainerName");
-    arg2->set_value(buildSettings.ContainerName.value());
-
-    NController::TRequest resultRequest = controller.Build(buildSettings);
-    EXPECT_EQ(expectedRequest.type(), resultRequest.type());
-    EXPECT_EQ(expectedRequest.args(0).name(), resultRequest.args(0).name());
-    EXPECT_EQ(expectedRequest.args(0).value(), resultRequest.args(0).value());
-    EXPECT_EQ(expectedRequest.args(1).name(), resultRequest.args(1).name());
-    EXPECT_EQ(expectedRequest.args(1).value(), resultRequest.args(1).value());
-}
-
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     auto result = RUN_ALL_TESTS();


### PR DESCRIPTION
Inside 692af3f seems to be a fix to the error [flown4qqqq](https://github.com/flown4qqqq) has encountered. I was not able to reproduce it - so please, check this commit out. Also, these structs were obsolete as now we use protobuf messages.

![photo_2025-05-02_00-21-57](https://github.com/user-attachments/assets/5150380d-588b-42f9-853d-ceb036ff5d40)
