### PR TITLE
Add GithubActions support and minor clang-tidy fixes

### DIFF
--- a/.github/workflows/clang-gtest.yml
+++ b/.github/workflows/clang-gtest.yml
@@ -1,0 +1,32 @@
+name: Clang gtest pipeline
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install build tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang cmake ninja-build
+
+    - name: Run cmake and ninja
+      run: |
+        mkdir build
+        cd build
+        cmake .. -G Ninja
+        ninja
+
+    - name: Run tests
+      run: |
+        cd build
+        ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ set(CMAKE_C_COMPILER "clang" CACHE STRING "C compiler" FORCE)
 include(FetchContent)
 
 # <ZeroMQ>
+set(ZMQ_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(CPPZMQ_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+
 FetchContent_Declare(
     zeromq_c
     GIT_REPOSITORY https://github.com/zeromq/libzmq.git
@@ -57,6 +60,8 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(googletest)
+include(GoogleTest)
+
 # </GTest>
 
 # <Protobuf>
@@ -125,12 +130,14 @@ find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
          "-warnings-as-errors=*"
      )
 
-     set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};-p=${CMAKE_BINARY_DIR};${CLANGTIDY_EXTRA_ARGS}" CACHE STRING "" FORCE)
+     set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};-p=${CMAKE_BINARY_DIR};--header-filter=^${CMAKE_SOURCE_DIR}/dasboot/;${CLANGTIDY_EXTRA_ARGS}" CACHE STRING "" FORCE)
  endif()
 
 # End clang-tidy
 
 include_directories(.)
+
+enable_testing()
 
 add_subdirectory(dasboot)
 

--- a/dasboot/cli/CMakeLists.txt
+++ b/dasboot/cli/CMakeLists.txt
@@ -18,4 +18,4 @@ target_link_libraries(
     cli
 )
 
-add_test(cli_gtests cli_ut)
+gtest_discover_tests(cli_ut)

--- a/dasboot/controller/CMakeLists.txt
+++ b/dasboot/controller/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(
     ProtobufMessages
 )
 
-add_test(tape_gtests controller_ut)
+gtest_discover_tests(controller_ut)


### PR DESCRIPTION
Now, if one of our unit tests for any module fails - commit which is pushed will be rejected, thanks GitHub Actions.

Fixed clang-tidy issues - up to this moment when building again after first build clang-tidy tended to run on dependencies too.

Also, disabled ```libzeromq``` and ```cppmq``` tests - faster fist compilation time and now we can run our tests using ```ctest``` command in GitHub Actions (it also ran dependencies tests) .