### PR TITLE
Refactoring CLI

### DIFF
--- a/dasboot/cli/cli.cpp
+++ b/dasboot/cli/cli.cpp
@@ -11,7 +11,6 @@ namespace NCli {
         return shortName + "," + longName;
     }
 
-
     void TParser::AddGlobalFlag(const string& shortName, const string& longName, bool& flag, const string& description) {
         App.add_flag(BuildFullName(shortName, longName), flag, description);
     }
@@ -54,110 +53,124 @@ namespace NCli {
         return 0;
     }
 
-    
     string TParser::GetHelp() const {
         return App.help();
     }
 
+    namespace {
+        // Dasboot description
+        static const std::string DasbootDescription = "A small containerization utility, written in C/C++. Made as team pet project.";
+    
+        // Common option descriptions
+        static const std::string ContainerNameDescription = "Container name";
+        static const std::string ContainerIdDescription = "Container ID";
+        static const std::string BuildFromFileDescription = "Create a container from a DasbootFile";
+        static const std::string ShowAllContainersDescription = "List all containers, including stopped ones.";
+        static const std::string DetachFlagDescription = "Detached mode: run command in the background";
+        static const std::string NoStdinFlagDescription = "Do not attach STDIN";
+    
+        // Command descriptions
+        static const std::string VersionDescription = "Print version information and quit";
+        static const std::string InfoDescription = "Display system-wide information";
+        static const std::string BuildDescription = "Create a container";
+        static const std::string RunDescription = "Run container in interactive mode";
+        static const std::string StartDescription = "Launch a container by name or ID depending on specified options";
+        static const std::string StopDescription = "Terminate a running container";
+        static const std::string PsDescription = "Display all available containers.";
+        static const std::string RmDescription = "Delete a container by name or ID depending on specified options";
+        static const std::string ExecDescription = "Run one or multiple commands inside an already running container";
+        static const std::string AttachDescription = "Connect a terminal to a running container by its ID or name for interactive management and output monitoring";
+    } // anonymous namespace
 
     void TParser::RegisterCommands(TMainSettings& mainSettings) {
-        // // dasboot --version
-        this->AddGlobalFlag("-v", "--version", mainSettings.Version.PrintVersion, "Print version information and quit");
-    
-        // Command 'info'
-        AddGlobalCommand("info", "Display system-wide information");
-    
-        // Command 'build'
-        AddGlobalCommand("build", "Creates a container");
-        this->AddLocalOption("build", "-n", "--name", mainSettings.BuildOptions.Name, "Container name");
-        this->AddLocalOption("build", "-f", "--file", mainSettings.BuildOptions.PathToDasbootFile, "Creates a container from a DasbootFile");
-    
-        // Command 'run'
-        AddGlobalCommand("run", "Run container in interactive mode");
-        this->AddLocalOption("run", "-n", "--name", mainSettings.RunOptions.Name, "Container name");
-    
-        // Command 'start'
-        AddGlobalCommand("start", "Launches a container by name or ID depending on specified options");
-        this->AddLocalOption("start", "-n", "--name",  mainSettings.StartOptions.Name, "Container name");
-        this->AddLocalOption("start", "-i", "--id",  mainSettings.StartOptions.Id, "Container ID");
-    
-        // Command 'stop'
-        AddGlobalCommand("stop", "Terminates a running container");
-        this->AddLocalOption("stop", "-n", "--name", mainSettings.StopOptions.Name, "Container name");
-        this->AddLocalOption("stop", "-i", "--id", mainSettings.StopOptions.Id, "Container ID");
-    
-        // Command 'ps'
-        AddGlobalCommand("ps", "Displays all available containers.");
-        this->AddLocalFlag("ps", "-a", "--all", mainSettings.PsOptions.ShowAll, "Lists all containers, including stopped ones.");
-    
-        // Command 'rm'
-        AddGlobalCommand("rm", "Deletes a container by name or ID depending on specified options");
-        this->AddLocalOption("rm", "-n", "--name", mainSettings.RmOptions.Name, "Container name");
-        this->AddLocalOption("rm", "-i", "--id", mainSettings.RmOptions.Id, "Container ID");
-    
-        // Command 'exec'
-        AddGlobalCommand("exec", "Runs one or multiple commands inside an already running container");
-        this->AddLocalOption("exec", "-n", "--name", mainSettings.ExecOptions.Name, "Container name");
-        this->AddLocalOption("exec", "-i", "--id", mainSettings.ExecOptions.Id, "Container ID");
-        this->AddLocalFlag("exec", "-d", "--detach", mainSettings.ExecOptions.Detach, "Detached mode: run command in the background");
-    
-        // Command 'attach'
-        AddGlobalCommand("attach", "Connects a terminal to a running container by its ID or name for interactive management and output monitoring");
-        this->AddLocalOption("attach", "-n", "--name", mainSettings.AttachOptions.Name, "Container name");
-        this->AddLocalOption("attach", "-i", "--id", mainSettings.AttachOptions.Id, "Container ID");
-        this->AddLocalFlag("attach", "", "--no-stdin", mainSettings.AttachOptions.NoStdin, "Do not attach STDIN");
-    
+        AddGlobalFlag("-v", "--version", mainSettings.Version.PrintVersion, VersionDescription);
+
+        AddGlobalCommand("info", InfoDescription);
+
+        AddGlobalCommand("build", BuildDescription);
+        AddLocalOption("build", "-n", "--name", mainSettings.BuildOptions.Name, ContainerNameDescription);
+        AddLocalOption("build", "-f", "--file", mainSettings.BuildOptions.PathToDasbootFile, BuildFromFileDescription);
+
+        AddGlobalCommand("run", RunDescription);
+        AddLocalOption("run", "-n", "--name", mainSettings.RunOptions.Name, ContainerNameDescription);
+
+        AddGlobalCommand("start", StartDescription);
+        AddLocalOption("start", "-n", "--name",  mainSettings.StartOptions.Name, ContainerNameDescription);
+        AddLocalOption("start", "-i", "--id",  mainSettings.StartOptions.Id, ContainerIdDescription);
+
+        AddGlobalCommand("stop", StopDescription);
+        AddLocalOption("stop", "-n", "--name", mainSettings.StopOptions.Name, ContainerNameDescription);
+        AddLocalOption("stop", "-i", "--id", mainSettings.StopOptions.Id, ContainerIdDescription);
+
+        AddGlobalCommand("ps", PsDescription);
+        AddLocalFlag("ps", "-a", "--all", mainSettings.PsOptions.ShowAll, ShowAllContainersDescription);
+
+        AddGlobalCommand("rm", RmDescription);
+        AddLocalOption("rm", "-n", "--name", mainSettings.RmOptions.Name, ContainerNameDescription);
+        AddLocalOption("rm", "-i", "--id", mainSettings.RmOptions.Id, ContainerIdDescription);
+
+        AddGlobalCommand("exec", ExecDescription);
+        AddLocalOption("exec", "-n", "--name", mainSettings.ExecOptions.Name, ContainerNameDescription);
+        AddLocalOption("exec", "-i", "--id", mainSettings.ExecOptions.Id, ContainerIdDescription);
+        AddLocalFlag("exec", "-d", "--detach", mainSettings.ExecOptions.Detach, DetachFlagDescription);
+
+        AddGlobalCommand("attach", AttachDescription);
+        AddLocalOption("attach", "-n", "--name", mainSettings.AttachOptions.Name, ContainerNameDescription);
+        AddLocalOption("attach", "-i", "--id", mainSettings.AttachOptions.Id, ContainerIdDescription);
+        AddLocalFlag("attach", "", "--no-stdin", mainSettings.AttachOptions.NoStdin, NoStdinFlagDescription);
     }
 
-
-    // Converter for converting parsed command-line strings to protobuf messages, which are then sent to controller handlers.
-    
     void TConverter::SendMainSettings(const TMainSettings& mainSettings, const std::string& command) {
-
         if (mainSettings.Version.PrintVersion) {
             //print version -- function in controller
         }
+
         if (command == "info") {
             //controller handle call
         }
+
         if (command == "build") {
             NMessages::TBuildOptions ProtoBuildOptions;
             ProtoBuildOptions = TConverter::ConvertBuildOptions(mainSettings.BuildOptions, ProtoBuildOptions);
             //controller handle call
-
-            NController::Build(ProtoBuildOptions);
-            
         } 
+
         if (command == "run") {
             NMessages::TRunOptions ProtoRunOptions;
             ProtoRunOptions = TConverter::ConvertRunOptions(mainSettings.RunOptions, ProtoRunOptions);
             //controller handle call
         } 
+
         if (command == "start") {
             NMessages::TStartOptions ProtoStartOptions;
             ProtoStartOptions = TConverter::ConvertStartOptions(mainSettings.StartOptions, ProtoStartOptions);
             //controller handle call
         }
+
         if (command == "stop") {
             NMessages::TStopOptions ProtoStopOptions;
             ProtoStopOptions = TConverter::ConvertStopOptions(mainSettings.StopOptions, ProtoStopOptions);
             //controller handle call
         }
+
         if (command == "ps") {
             NMessages::TPsOptions ProtoPsOptions;
             ProtoPsOptions = TConverter::ConvertPsOptions(mainSettings.PsOptions, ProtoPsOptions);
             //controller handle call
         }
+
         if (command == "rm") {
             NMessages::TRmOptions ProtoRmOptions;
             ProtoRmOptions = TConverter::ConvertRmOptions(mainSettings.RmOptions, ProtoRmOptions);
             //controller handle call
         }
+
         if (command == "exec") {
             NMessages::TExecOptions ProtoExecOptions;
             ProtoExecOptions = TConverter::ConvertExecOptions(mainSettings.ExecOptions, ProtoExecOptions);
             //controller handle call
         }
+
         if (command == "attach") {
             NMessages::TAttachOptions ProtoAttachOptions;
             ProtoAttachOptions = TConverter::ConvertAttachOptions(mainSettings.AttachOptions, ProtoAttachOptions);
@@ -169,9 +182,11 @@ namespace NCli {
         if (options.Name.has_value()) {
             protoOptions.set_name(options.Name.value());
         }
+
         if (options.PathToDasbootFile.has_value()) {
             protoOptions.set_pathtodasbootfile(options.PathToDasbootFile.value());
         }
+
         return protoOptions;
     }
 
@@ -179,6 +194,7 @@ namespace NCli {
         if (options.Name.has_value()) {
             protoOptions.set_name(options.Name.value());
         }
+
         return protoOptions;
     }
 
@@ -186,9 +202,11 @@ namespace NCli {
         if (options.Name.has_value()) {
             protoOptions.set_name(options.Name.value());
         }
+
         if (options.Id.has_value()) {
             protoOptions.set_id(options.Id.value());
         }
+
         return protoOptions;
     }
     
@@ -196,9 +214,11 @@ namespace NCli {
         if (options.Name.has_value()) {
             protoOptions.set_name(options.Name.value());
         }
+
         if (options.Id.has_value()) {
             protoOptions.set_id(options.Id.value());
         }
+
         return protoOptions;
     }
     
@@ -206,6 +226,7 @@ namespace NCli {
         if (options.ShowAll) {
             protoOptions.set_show_all(options.ShowAll);
         }
+
         return protoOptions;
     }
     
@@ -213,9 +234,11 @@ namespace NCli {
         if (options.Name.has_value()) {
             protoOptions.set_name(options.Name.value());
         }
+
         if (options.Id.has_value()) {
             protoOptions.set_id(options.Id.value());
         }
+
         return protoOptions;
     }
     
@@ -223,12 +246,15 @@ namespace NCli {
         if (options.Name.has_value()) {
             protoOptions.set_name(options.Name.value());
         }
+
         if (options.Id.has_value()) {
             protoOptions.set_id(options.Id.value());
         }
+
         if (options.Detach) {
             protoOptions.set_detach(options.Detach);
         }
+
         return protoOptions;
     }
     
@@ -236,23 +262,17 @@ namespace NCli {
         if (options.Name.has_value()) {
             protoOptions.set_name(options.Name.value());
         }
+
         if (options.Id.has_value()) {
             protoOptions.set_id(options.Id.value());
         }
+
         if (options.NoStdin) {
             protoOptions.set_nostdin(options.NoStdin);
         }
+
         return protoOptions;
     }
-
-
-
-
-    // There will be constant values with dasboot's descriptions
-    namespace {
-        static const std::string DasbootDescription = "A small containerization utility, written in C/C++. Made as team pet project.";
-    } // anonymous namespace
-
 
     std::unique_ptr<TParser> MakeDasbootParser(TMainSettings& settings) {
         std::unique_ptr<TParser> parser(new TParser{DasbootDescription});

--- a/dasboot/cli/cli_ut.cpp
+++ b/dasboot/cli/cli_ut.cpp
@@ -1,7 +1,5 @@
-#include <gtest/gtest.h>
-
 #include <string>
-
+#include <gtest/gtest.h>
 #include <dasboot/cli/cli.hpp>
 
 TEST(CliUt, ConstructHelp) {
@@ -59,594 +57,549 @@ OPTIONS:
 
 SUBCOMMANDS:
   info                        Display system-wide information 
-  build                       Creates a container 
+  build                       Create a container 
   run                         Run container in interactive mode 
-  start                       Launches a container by name or ID depending on specified options 
-  stop                        Terminates a running container 
-  ps                          Displays all available containers. 
-  rm                          Deletes a container by name or ID depending on specified options 
-  exec                        Runs one or multiple commands inside an already running container 
-  attach                      Connects a terminal to a running container by its ID or name for 
+  start                       Launch a container by name or ID depending on specified options 
+  stop                        Terminate a running container 
+  ps                          Display all available containers. 
+  rm                          Delete a container by name or ID depending on specified options 
+  exec                        Run one or multiple commands inside an already running container 
+  attach                      Connect a terminal to a running container by its ID or name for 
                               interactive management and output monitoring 
 )";
 
     ASSERT_EQ(help, excpected);
 }
 
-//---------------------- COMMAND BUILD TESTS------------------------------
 TEST(CliUt, GetProtoCommandBuild0) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "build", "-n", "meow", "-f", "/home/bibeda"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TBuildOptions ProtoBuildOptions;
-  ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
-  auto protoText = ProtoBuildOptions.DebugString();
+    NMessages::TBuildOptions ProtoBuildOptions;
+    ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
+    auto protoText = ProtoBuildOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 pathtodasbootfile: "/home/bibeda"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
 TEST(CliUt, GetProtoCommandBuild1) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "build", "--name", "meow"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TBuildOptions ProtoBuildOptions;
-  ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
-  auto protoText = ProtoBuildOptions.DebugString();
+    NMessages::TBuildOptions ProtoBuildOptions;
+    ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
+    auto protoText = ProtoBuildOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
 TEST(CliUt, GetProtoCommandBuild2) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "build", "--file", "/home/bibeda"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TBuildOptions ProtoBuildOptions;
-  ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
-  auto protoText = ProtoBuildOptions.DebugString();
+    NMessages::TBuildOptions ProtoBuildOptions;
+    ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
+    auto protoText = ProtoBuildOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(pathtodasbootfile: "/home/bibeda"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandBuild3) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "build"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TBuildOptions ProtoBuildOptions;
-  ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
-  auto protoText = ProtoBuildOptions.DebugString();
+    NMessages::TBuildOptions ProtoBuildOptions;
+    ProtoBuildOptions = NCli::TConverter::ConvertBuildOptions(settings.BuildOptions, ProtoBuildOptions);
+    auto protoText = ProtoBuildOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"()";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
-//-------------------------------- COMMAND RUN TESTS --------------------------------
 
 TEST(CliUt, GetProtoCommandRun0) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "run", "-n", "meow"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TRunOptions ProtoRunOptions;
-  ProtoRunOptions = NCli::TConverter::ConvertRunOptions(settings.RunOptions, ProtoRunOptions);
-  auto protoText = ProtoRunOptions.DebugString();
+    NMessages::TRunOptions ProtoRunOptions;
+    ProtoRunOptions = NCli::TConverter::ConvertRunOptions(settings.RunOptions, ProtoRunOptions);
+    auto protoText = ProtoRunOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandRun1) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "run", "--name", "meow"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TRunOptions ProtoRunOptions;
-  ProtoRunOptions = NCli::TConverter::ConvertRunOptions(settings.RunOptions, ProtoRunOptions);
-  auto protoText = ProtoRunOptions.DebugString();
+    NMessages::TRunOptions ProtoRunOptions;
+    ProtoRunOptions = NCli::TConverter::ConvertRunOptions(settings.RunOptions, ProtoRunOptions);
+    auto protoText = ProtoRunOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandRun2) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "run"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TRunOptions ProtoRunOptions;
-  ProtoRunOptions = NCli::TConverter::ConvertRunOptions(settings.RunOptions, ProtoRunOptions);
-  auto protoText = ProtoRunOptions.DebugString();
+    NMessages::TRunOptions ProtoRunOptions;
+    ProtoRunOptions = NCli::TConverter::ConvertRunOptions(settings.RunOptions, ProtoRunOptions);
+    auto protoText = ProtoRunOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"()";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
-
-//---------------------------- COMMAND START TESTS ----------------------------------
-
 
 TEST(CliUt, GetProtoCommandStart0) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "start", "-n", "meow", "--id", "12345"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TStartOptions ProtoStartOptions;
-  ProtoStartOptions = NCli::TConverter::ConvertStartOptions(settings.StartOptions, ProtoStartOptions);
-  auto protoText = ProtoStartOptions.DebugString();
+    NMessages::TStartOptions ProtoStartOptions;
+    ProtoStartOptions = NCli::TConverter::ConvertStartOptions(settings.StartOptions, ProtoStartOptions);
+    auto protoText = ProtoStartOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 id: "12345"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandStart1) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "start", "--name", "meow"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TStartOptions ProtoStartOptions;
-  ProtoStartOptions = NCli::TConverter::ConvertStartOptions(settings.StartOptions, ProtoStartOptions);
-  auto protoText = ProtoStartOptions.DebugString();
+    NMessages::TStartOptions ProtoStartOptions;
+    ProtoStartOptions = NCli::TConverter::ConvertStartOptions(settings.StartOptions, ProtoStartOptions);
+    auto protoText = ProtoStartOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandStart2) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "start"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TStartOptions ProtoStartOptions;
-  ProtoStartOptions = NCli::TConverter::ConvertStartOptions(settings.StartOptions, ProtoStartOptions);
-  auto protoText = ProtoStartOptions.DebugString();
+    NMessages::TStartOptions ProtoStartOptions;
+    ProtoStartOptions = NCli::TConverter::ConvertStartOptions(settings.StartOptions, ProtoStartOptions);
+    auto protoText = ProtoStartOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"()";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-//---------------------------- COMMAND STOP TESTS ----------------------------------
-
-
 TEST(CliUt, GetProtoCommandStop0) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "stop", "-n", "meow", "--id", "12345"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TStopOptions ProtoStopOptions;
-  ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
-  auto protoText = ProtoStopOptions.DebugString();
+    NMessages::TStopOptions ProtoStopOptions;
+    ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
+    auto protoText = ProtoStopOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 id: "12345"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
 TEST(CliUt, GetProtoCommandStop1) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "stop", "-i", "12345"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TStopOptions ProtoStopOptions;
-  ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
-  auto protoText = ProtoStopOptions.DebugString();
+    NMessages::TStopOptions ProtoStopOptions;
+    ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
+    auto protoText = ProtoStopOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(id: "12345"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
 TEST(CliUt, GetProtoCommandStop2) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "stop", "--name", "meow"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TStopOptions ProtoStopOptions;
-  ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
-  auto protoText = ProtoStopOptions.DebugString();
+    NMessages::TStopOptions ProtoStopOptions;
+    ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
+    auto protoText = ProtoStopOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandStop3) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "stop"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TStopOptions ProtoStopOptions;
-  ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
-  auto protoText = ProtoStopOptions.DebugString();
+    NMessages::TStopOptions ProtoStopOptions;
+    ProtoStopOptions = NCli::TConverter::ConvertStopOptions(settings.StopOptions, ProtoStopOptions);
+    auto protoText = ProtoStopOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"()";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
-
-//---------------------------- COMMAND PS TESTS ----------------------------------
-
-
 TEST(CliUt, GetProtoCommandPs0) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "ps", "--all", "1"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TPsOptions ProtoPsOptions;
-  ProtoPsOptions = NCli::TConverter::ConvertPsOptions(settings.PsOptions, ProtoPsOptions);
-  auto protoText = ProtoPsOptions.DebugString();
+    NMessages::TPsOptions ProtoPsOptions;
+    ProtoPsOptions = NCli::TConverter::ConvertPsOptions(settings.PsOptions, ProtoPsOptions);
+    auto protoText = ProtoPsOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(show_all: true
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
-
 
 TEST(CliUt, GetProtoCommandPs1) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "ps"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TPsOptions ProtoPsOptions;
-  ProtoPsOptions = NCli::TConverter::ConvertPsOptions(settings.PsOptions, ProtoPsOptions);
-  auto protoText = ProtoPsOptions.DebugString();
+    NMessages::TPsOptions ProtoPsOptions;
+    ProtoPsOptions = NCli::TConverter::ConvertPsOptions(settings.PsOptions, ProtoPsOptions);
+    auto protoText = ProtoPsOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"()";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
-//---------------------------- COMMAND RM TESTS ----------------------------------
-
-
 TEST(CliUt, GetProtoCommandRm0) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "rm", "-n", "meow", "-i", "12345"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TRmOptions ProtoRmOptions;
-  ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
-  auto protoText = ProtoRmOptions.DebugString();
+    NMessages::TRmOptions ProtoRmOptions;
+    ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
+    auto protoText = ProtoRmOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 id: "12345"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
 TEST(CliUt, GetProtoCommandRm1) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "rm", "--name", "MEOW"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TRmOptions ProtoRmOptions;
-  ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
-  auto protoText = ProtoRmOptions.DebugString();
+    NMessages::TRmOptions ProtoRmOptions;
+    ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
+    auto protoText = ProtoRmOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "MEOW"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
 TEST(CliUt, GetProtoCommandRm2) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "rm", "--id", "1234512345"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TRmOptions ProtoRmOptions;
-  ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
-  auto protoText = ProtoRmOptions.DebugString();
+    NMessages::TRmOptions ProtoRmOptions;
+    ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
+    auto protoText = ProtoRmOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(id: "1234512345"
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandRm3) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "rm"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TRmOptions ProtoRmOptions;
-  ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
-  auto protoText = ProtoRmOptions.DebugString();
+    NMessages::TRmOptions ProtoRmOptions;
+    ProtoRmOptions = NCli::TConverter::ConvertRmOptions(settings.RmOptions, ProtoRmOptions);
+    auto protoText = ProtoRmOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"()";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
-//---------------------------- COMMAND EXEC TESTS ----------------------------------
-
-
 TEST(CliUt, GetProtoCommandExec0) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "exec", "-n", "meow", "-i", "12345", "-d", "1"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TExecOptions ProtoExecOptions;
-  ProtoExecOptions = NCli::TConverter::ConvertExecOptions(settings.ExecOptions, ProtoExecOptions);
-  auto protoText = ProtoExecOptions.DebugString();
+    NMessages::TExecOptions ProtoExecOptions;
+    ProtoExecOptions = NCli::TConverter::ConvertExecOptions(settings.ExecOptions, ProtoExecOptions);
+    auto protoText = ProtoExecOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 id: "12345"
 detach: true
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 TEST(CliUt, GetProtoCommandExec1) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "exec", "--detach", "0"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TExecOptions ProtoExecOptions;
-  ProtoExecOptions = NCli::TConverter::ConvertExecOptions(settings.ExecOptions, ProtoExecOptions);
-  auto protoText = ProtoExecOptions.DebugString();
+    NMessages::TExecOptions ProtoExecOptions;
+    ProtoExecOptions = NCli::TConverter::ConvertExecOptions(settings.ExecOptions, ProtoExecOptions);
+    auto protoText = ProtoExecOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"()";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
 
-
-
-//---------------------------- COMMAND ATTACH TESTS ----------------------------------
-
-
 TEST(CliUt, GetProtoCommandAttach) {
-  NCli::TMainSettings settings;
-  auto parser = NCli::MakeDasbootParser(settings);
+    NCli::TMainSettings settings;
+    auto parser = NCli::MakeDasbootParser(settings);
 
-  const char* argv0[] = {
+    const char* argv0[] = {
     "./dasboot", "attach", "-n", "meow", "-i", "12345", "--no-stdin", "1"
-  };
-  int argc = sizeof(argv0)/sizeof(argv0[0]);
-  char** argv = const_cast<char**>(argv0);
+    };
+    int argc = sizeof(argv0)/sizeof(argv0[0]);
+    char** argv = const_cast<char**>(argv0);
 
-  parser->Parse(argc, argv);
+    parser->Parse(argc, argv);
 
-  NMessages::TAttachOptions ProtoAttachOptions;
-  ProtoAttachOptions = NCli::TConverter::ConvertAttachOptions(settings.AttachOptions, ProtoAttachOptions);
-  auto protoText = ProtoAttachOptions.DebugString();
+    NMessages::TAttachOptions ProtoAttachOptions;
+    ProtoAttachOptions = NCli::TConverter::ConvertAttachOptions(settings.AttachOptions, ProtoAttachOptions);
+    auto protoText = ProtoAttachOptions.DebugString();
 
-  auto excpected = 
+    auto excpected =
 R"(name: "meow"
 id: "12345"
 nostdin: true
 )";
 
-  ASSERT_EQ(protoText, excpected);
+    ASSERT_EQ(protoText, excpected);
 }
-
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/dasboot/proto/messages.proto
+++ b/dasboot/proto/messages.proto
@@ -3,65 +3,63 @@ syntax = "proto3";
 package NMessages;
 
 enum ReturnCode {
-  SUCESS = 0;
-  ERROR = 1;
+    SUCESS = 0;
+    ERROR = 1;
 }
 
 // TO DO: later change TArg for every command
 message TArg {
-  optional string name = 1;
-  optional string value = 2;
+    optional string name = 1;
+    optional string value = 2;
 }
 
 message TRequest {
-  optional string type = 1;
-  repeated TArg args = 2;
+    optional string type = 1;
+    repeated TArg args = 2;
 }
 
 message TResponse {
-  optional ReturnCode returnCode = 1;
-  optional string reuturnMessage = 2;
-  optional string returnData = 3;
+    optional ReturnCode returnCode = 1;
+    optional string reuturnMessage = 2;
+    optional string returnData = 3;
 }
 
-// For cli
 message TBuildOptions {
-  optional string name = 1;
-  optional string pathtodasbootfile = 2;
-
+    optional string name = 1;
+    optional string pathtodasbootfile = 2;
 }
 
 message TRunOptions{
-  optional string name = 1;
+    optional string name = 1;
 }
 
 message TStartOptions{
-  optional string name = 1;
-  optional string id = 2;
+    optional string name = 1;
+    optional string id = 2;
 }
 
 message TStopOptions {
-  optional string name = 1;
-  optional string id = 2;
+    optional string name = 1;
+    optional string id = 2;
 }
 
 message TPsOptions {
-  optional bool show_all = 1;
+    optional bool show_all = 1;
 }
 
 message TRmOptions {
-  optional string name = 1;
-  optional string id = 2;
+    optional string name = 1;
+    optional string id = 2;
 }
 
 message TExecOptions {
-  optional string name = 1;
-  optional string id = 2;
-  optional bool detach = 3;
+    optional string name = 1;
+    optional string id = 2;
+    optional bool detach = 3;
 }
 
 message TAttachOptions {
-  optional string name = 1;
-  optional string id = 2;
-  optional bool nostdin = 3;
+    optional string name = 1;
+    optional string id = 2;
+    optional bool nostdin = 3;
 }


### PR DESCRIPTION
Changes:

1. Tabs with 2 spaces were replaced by tabs with 4 spaces;
2. Some unnecessary comments were erased;
3. Rewrite descriptions of commands.
