### PR TITLE
Fix CLI11 include path and clang-tidy error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(cli11)
+
+include_directories(${cli11_SOURCE_DIR}/include)
 # </Cli11>
 
 # <GTest>

--- a/dasboot/controller/controller.cpp
+++ b/dasboot/controller/controller.cpp
@@ -1,6 +1,4 @@
 #include <dasboot/controller/controller.hpp>
-#include <dasboot/cli/cli.hpp>
-
 
 namespace NController {
 

--- a/dasboot/controller/controller.hpp
+++ b/dasboot/controller/controller.hpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <stdlib.h>
 
-#include <dasboot/cli/cli.hpp>
 #include <messages.pb.h>
 
 #define TZeroMQSocket int // TODO: VoidZeroNull0, temporary solution

--- a/dasboot/cru/cru.hpp
+++ b/dasboot/cru/cru.hpp
@@ -8,7 +8,7 @@ public:
         return *this;
     }
 
-    operator std::string() const {
+    operator std::string() const { // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
         return Stream.str();
     }
 protected:


### PR DESCRIPTION
Now, 100% fixed include path for CLI11. Also, clang-tidy was having problem with cru module - fixed.