### PR TITLE
Create unit-tests for Filesystem's wrapper 

### DIFF
--- a/dasboot/CMakeLists.txt
+++ b/dasboot/CMakeLists.txt
@@ -5,5 +5,6 @@ add_subdirectory(proto)
 add_subdirectory(controller)
 
 add_executable(dasboot app/main.cpp)
+apply_compile_flags(dasboot)
 target_link_libraries(dasboot PUBLIC cli)
 target_link_libraries(dasboot PUBLIC controller)

--- a/dasboot/cru/CMakeLists.txt
+++ b/dasboot/cru/CMakeLists.txt
@@ -17,4 +17,14 @@ target_link_libraries(
     cru
 )
 
-add_test(cru_gtests cru_ut)
+add_executable(fs_ut fs_ut.cpp)
+apply_compile_flags(fs_ut)
+
+target_link_libraries(
+    fs_ut
+    PRIVATE
+    GTest::gtest
+    cru
+)
+
+add_test(cru_gtests fs_ut)

--- a/dasboot/cru/common.hpp
+++ b/dasboot/cru/common.hpp
@@ -17,7 +17,8 @@ protected:
     std::stringstream Stream;
 };
 
-class TCommonStatus {
+namespace NCommon {
+class TStatus {
 public:
     enum ECode {
         Success = 0,
@@ -27,3 +28,5 @@ public:
     ECode Code = ECode::Success;
     std::string Error = "";
 };
+
+} // namespace NCommon

--- a/dasboot/cru/cru_ut.cpp
+++ b/dasboot/cru/cru_ut.cpp
@@ -17,7 +17,31 @@ TEST(CruUt, CheckMakeString) {
     EXPECT_EQ(message, str);
 }
 
-// Write tests for NOs
+TEST(CruUt, CheckTPipeBase) {
+    NOs::TPipe pipe;
+    std::string message = "Hello, World!";
+    pipe.Write(message);
+    std::string readMessage = pipe.ReadAll();
+    EXPECT_EQ(message, readMessage);
+}
+
+TEST(CruUt, CheckTPipeWithFork) {
+    NOs::TPipe pipe;
+    std::string message = "Hello, World!";
+    pid_t pid = fork();
+    if (pid == 0) {
+        pipe.CloseWrite();
+        std::string readMessage = pipe.ReadAll();
+        EXPECT_EQ(message, readMessage);
+        exit(0);
+    } else if (pid > 0) {
+        pipe.CloseRead();
+        pipe.Write(message);
+        waitpid(pid, nullptr, 0);
+    } else {
+        FAIL() << "Fork failed";
+    }
+}
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/dasboot/cru/fs_ut.cpp
+++ b/dasboot/cru/fs_ut.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <iomanip>
+
+#include <dasboot/cru/common.hpp>
+#include <dasboot/cru/os.hpp>
+
+TEST(CruUt, CreateSimpleFile) {
+    std::string path = "testfile.txt";
+    NCommon::TStatus status = NOs::CreateFile(path);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Success);
+    EXPECT_TRUE(NOs::IsFileExists(path));
+    NOs::RemoveFile(path);
+    EXPECT_TRUE(!NOs::IsFileExists(path));
+}
+
+TEST(CruUt, CreateDeepFileError) {
+    std::string path = "tmp/testfile.txt";
+    NCommon::TStatus status = NOs::CreateFile(path);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Failed);
+    EXPECT_EQ(status.Error, "Path 'tmp' does not exists");
+    EXPECT_TRUE(!NOs::IsFileExists(path));
+    EXPECT_TRUE(!NOs::IsDirectoryExists("tmp"));
+}
+
+TEST(CruUt, CreateDeepFile) {
+    std::string path = "tmp/testfile.txt";
+    NCommon::TStatus status = NOs::CreateFile(path, true, 0755);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Success);
+    EXPECT_TRUE(NOs::IsFileExists(path));
+    NOs::RemoveFile(path);
+    EXPECT_TRUE(!NOs::IsFileExists(path));
+    NOs::RemoveDirectory("tmp");
+    EXPECT_TRUE(!NOs::IsDirectoryExists("tmp"));
+}
+
+TEST(CruUt, CreateSimpleDirectory) {
+    std::string path = "tmp";
+    NCommon::TStatus status = NOs::CreateDirectory(path);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Success);
+    EXPECT_TRUE(NOs::IsDirectoryExists(path));
+    NOs::RemoveDirectory(path);
+    EXPECT_TRUE(!NOs::IsDirectoryExists(path));
+}
+
+TEST(CruUt, CreateDeepDirectoryError) {
+    std::string path = "tmp/testdir";
+    NCommon::TStatus status = NOs::CreateDirectory(path);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Failed);
+    EXPECT_EQ(status.Error, "Path 'tmp' does not exists");
+    EXPECT_TRUE(!NOs::IsDirectoryExists(path));
+    NOs::RemoveDirectory(path);
+    EXPECT_TRUE(!NOs::IsDirectoryExists(path));
+}
+
+TEST(CruUt, CreateDeepDirectory) {
+    std::string path = "tmp/testdir";
+    NCommon::TStatus status = NOs::CreateDirectory(path, true);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Success);
+    EXPECT_TRUE(NOs::IsDirectoryExists(path));
+    NOs::RemoveDirectory(path);
+    NOs::RemoveDirectory("tmp");
+    EXPECT_TRUE(!NOs::IsDirectoryExists(path));
+    EXPECT_TRUE(!NOs::IsDirectoryExists("tmp"));
+}
+
+TEST(CruUt, CreateDirectoryAndFiles) {
+    std::string path = "tmp/testdir";
+    NCommon::TStatus status = NOs::CreateDirectory(path, true);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Success);
+    EXPECT_TRUE(NOs::IsDirectoryExists(path));
+
+    std::string filePath = path + "/testfile.txt";
+    status = NOs::CreateFile(filePath, true);
+    EXPECT_EQ(status.Code, NCommon::TStatus::ECode::Success);
+    EXPECT_TRUE(NOs::IsFileExists(filePath));
+
+    auto removeStatus = NOs::RemoveDirectory("tmp", false);
+
+    EXPECT_EQ(removeStatus.Error, "");
+    EXPECT_EQ(removeStatus.Code, NCommon::TStatus::ECode::Success);
+
+    EXPECT_TRUE(!NOs::IsDirectoryExists(path));
+    EXPECT_TRUE(!NOs::IsFileExists(filePath));
+}
+
+TEST(CruUt, CheckBackDirectory) {
+    std::string testDir = "ut_tmp_dir";
+    {
+        auto status = NOs::CreateDirectory(testDir);
+        EXPECT_EQ(status.Error, "");
+        EXPECT_TRUE(NOs::IsDirectoryExists(testDir));
+    }
+    {
+        auto status = NOs::ChangeDirectory(testDir);
+        EXPECT_EQ(status.Error, "");
+    }
+    {
+        auto status = NOs::ChangeDirectory("..");
+        EXPECT_EQ(status.Error, "");
+    }
+    {
+        auto status = NOs::RemoveDirectory(testDir);
+        EXPECT_EQ(status.Error, "");
+        EXPECT_TRUE(!NOs::IsDirectoryExists(testDir));    
+    }
+}
+
+TEST(CruUt, CheckCopyFiles) {
+    std::string from = "first";
+    std::string fromFile = "first/file";
+    std::string to = "second";
+    std::string toFile = "second/file";
+
+    NOs::CreateDirectory(from);
+    NOs::CreateFile(fromFile);
+    NOs::Copy(from, to);
+
+    EXPECT_TRUE(NOs::IsFileExists(toFile));
+    {
+        auto status = NOs::RemoveDirectory(from, false);
+        EXPECT_EQ(status.Error, "");
+        EXPECT_TRUE(!NOs::IsDirectoryExists(from));
+    }
+    {
+        auto status = NOs::RemoveDirectory(to, false);
+        EXPECT_EQ(status.Error, "");
+        EXPECT_TRUE(!NOs::IsDirectoryExists(to));
+    }
+}
+
+int main(int argc, char** argv) {
+    std::string testDir = "ut_tmp_dir";
+    NOs::CreateDirectory(testDir);
+    NOs::ChangeDirectory(testDir);
+
+    ::testing::InitGoogleTest(&argc, argv);
+    auto result = RUN_ALL_TESTS();
+
+    NOs::ChangeDirectory("..");
+
+    bool isEmpty = NOs::IsDirectoryEmpty(testDir);
+    NOs::RemoveDirectory(testDir, false);
+
+    if (!isEmpty) {
+        throw std::runtime_error(MakeString() << "Directory '" << testDir << "' is not empty after tests.");
+    }
+
+    return result;
+}

--- a/dasboot/cru/os.hpp
+++ b/dasboot/cru/os.hpp
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <filesystem>
 #include <vector>
+#include <fcntl.h>
 
 #include "common.hpp"
 
@@ -29,21 +30,25 @@ namespace NOs {
     bool IsFileExists(const std::string& path);
     bool IsDirectory(const std::string& path);
     bool IsDirectoryExists(const std::string& path);
+    bool IsDirectoryEmpty(const std::string& path);
 
-    TCommonStatus WriteToFile(const std::string& path, const std::string& text);
-    TCommonStatus CopyFile(const std::string& source, const std::string& target);
+    NCommon::TStatus WriteToFile(const std::string& path, const std::string& text);
+    NCommon::TStatus Copy(const std::string& source, const std::string& target);
 
-    TCommonStatus SetClearEnv();
-    TCommonStatus Exec(const std::string& program, char* const argv[]);
-    TCommonStatus Clone(const TCloneArgs& args);
+    NCommon::TStatus SetClearEnv();
+    NCommon::TStatus Exec(const std::string& program, char* const argv[]);
+    NCommon::TStatus Clone(const TCloneArgs& args);
 
-    TCommonStatus Mount(const std::string& source, const std::string& target, const std::string& type, uint64_t flags);
-    TCommonStatus Unmount(const std::string& putOld);
-    TCommonStatus PivotRoot(const std::string& rootfs, const std::string& oldRoot);
+    NCommon::TStatus Mount(const std::string& source, const std::string& target, const std::string& type, uint64_t flags);
+    NCommon::TStatus Unmount(const std::string& putOld);
+    NCommon::TStatus PivotRoot(const std::string& rootfs, const std::string& oldRoot);
 
-    TCommonStatus ChangeDirectory(const std::string& path);
-    TCommonStatus MakeDirectory(const std::string& path, mode_t mode = 0755);
-    TCommonStatus RemoveDirectory(const std::string& path);
+    NCommon::TStatus CreateFile(const std::string& path, bool isDeep = false, mode_t mode = 0755);
+    NCommon::TStatus RemoveFile(const std::string& path);
+
+    NCommon::TStatus ChangeDirectory(const std::string& path);
+    NCommon::TStatus CreateDirectory(const std::string& path, bool isDeep = false, mode_t mode = 0755);
+    NCommon::TStatus RemoveDirectory(const std::string& path, bool shouldBeEmpty = true);
 
     pid_t GetCurrentPid();
     uid_t GetCurrentUid();


### PR DESCRIPTION
This pr creates ut for wrappers on std::filesystem and syscalls to filesystem.

In addition, bugs have been fixed.
