### PR TITLE
Controller class

### DIFF
--- a/dasboot/app/main.cpp
+++ b/dasboot/app/main.cpp
@@ -16,7 +16,8 @@ int main(int argc, char* argv[]) {
         return 0;
     }
     
-    NCli::TConverter::SendMainSettings(settings, command);
+    NCli::TSender Sender("ipc:///tmp/mysocket"); 
+    Sender.SendMainSettings(settings, command);
     
     return 0;
 }

--- a/dasboot/cli/CMakeLists.txt
+++ b/dasboot/cli/CMakeLists.txt
@@ -4,7 +4,9 @@ set(SOURCES cli.cpp)
 set(HEADERS cli.hpp)
 add_library(cli ${SOURCES} ${HEADERS})
 apply_compile_flags(cli)
-target_link_libraries(cli PUBLIC CLI11::CLI11 ProtobufMessages)
+target_link_libraries(cli PUBLIC CLI11::CLI11)
+target_link_libraries(cli PUBLIC ProtobufMessages)
+target_link_libraries(cli PUBLIC controller)
 
 # tests:
 
@@ -17,6 +19,7 @@ target_link_libraries(
     GTest::gtest
     cli
     ProtobufMessages
+    controller
 )
 
 gtest_discover_tests(cli_ut)

--- a/dasboot/cli/cli.cpp
+++ b/dasboot/cli/cli.cpp
@@ -128,57 +128,63 @@ namespace NCli {
             //print version -- function in controller
         }
 
-        if (command == "info") {
+        else if (command == "info") {
             //controller handle call
         }
 
-        if (command == "build") {
+        else if (command == "build") {
             NMessages::TBuildOptions ProtoBuildOptions;
             ProtoBuildOptions = TConverter::ConvertBuildOptions(mainSettings.BuildOptions, ProtoBuildOptions);
             Controller.Build(ProtoBuildOptions);
         } 
 
-        if (command == "run") {
+        else if (command == "run") {
             NMessages::TRunOptions ProtoRunOptions;
             ProtoRunOptions = TConverter::ConvertRunOptions(mainSettings.RunOptions, ProtoRunOptions);
             Controller.Run(ProtoRunOptions);
         } 
 
-        if (command == "start") {
+        else if (command == "start") {
             NMessages::TStartOptions ProtoStartOptions;
             ProtoStartOptions = TConverter::ConvertStartOptions(mainSettings.StartOptions, ProtoStartOptions);
             Controller.Start(ProtoStartOptions);
         }
 
-        if (command == "stop") {
+        else if (command == "stop") {
             NMessages::TStopOptions ProtoStopOptions;
             ProtoStopOptions = TConverter::ConvertStopOptions(mainSettings.StopOptions, ProtoStopOptions);
             Controller.Stop(ProtoStopOptions);
         }
 
-        if (command == "ps") {
+        else if (command == "ps") {
             NMessages::TPsOptions ProtoPsOptions;
             ProtoPsOptions = TConverter::ConvertPsOptions(mainSettings.PsOptions, ProtoPsOptions);
             Controller.Ps(ProtoPsOptions);
         }
 
-        if (command == "rm") {
+        else if (command == "rm") {
             NMessages::TRmOptions ProtoRmOptions;
             ProtoRmOptions = TConverter::ConvertRmOptions(mainSettings.RmOptions, ProtoRmOptions);
             Controller.Rm(ProtoRmOptions);
         }
 
-        if (command == "exec") {
+        else if (command == "exec") {
             NMessages::TExecOptions ProtoExecOptions;
             ProtoExecOptions = TConverter::ConvertExecOptions(mainSettings.ExecOptions, ProtoExecOptions);
             Controller.Exec(ProtoExecOptions);
         }
 
-        if (command == "attach") {
+        else if (command == "attach") {
             NMessages::TAttachOptions ProtoAttachOptions;
             ProtoAttachOptions = TConverter::ConvertAttachOptions(mainSettings.AttachOptions, ProtoAttachOptions);
             //controller handle call
         }
+
+        else {
+            throw std::exception("Unknown command");
+        }
+
+        
     }
 
     NMessages::TBuildOptions TConverter::ConvertBuildOptions(const NCli::TBuildOptions& options, NMessages::TBuildOptions& protoOptions) {

--- a/dasboot/cli/cli.cpp
+++ b/dasboot/cli/cli.cpp
@@ -181,7 +181,7 @@ namespace NCli {
         }
 
         else {
-            throw std::exception("Unknown command");
+            throw std::runtime_error("Unknown command");
         }
 
         

--- a/dasboot/cli/cli.cpp
+++ b/dasboot/cli/cli.cpp
@@ -120,7 +120,10 @@ namespace NCli {
         AddLocalFlag("attach", "", "--no-stdin", mainSettings.AttachOptions.NoStdin, NoStdinFlagDescription);
     }
 
-    void TConverter::SendMainSettings(const TMainSettings& mainSettings, const std::string& command) {
+    TSender::TSender(const std::string adress)
+    : Controller(adress) {}
+
+    void TSender::SendMainSettings(const TMainSettings& mainSettings, const std::string& command) {
         if (mainSettings.Version.PrintVersion) {
             //print version -- function in controller
         }
@@ -132,43 +135,43 @@ namespace NCli {
         if (command == "build") {
             NMessages::TBuildOptions ProtoBuildOptions;
             ProtoBuildOptions = TConverter::ConvertBuildOptions(mainSettings.BuildOptions, ProtoBuildOptions);
-            //controller handle call
+            Controller.Build(ProtoBuildOptions);
         } 
 
         if (command == "run") {
             NMessages::TRunOptions ProtoRunOptions;
             ProtoRunOptions = TConverter::ConvertRunOptions(mainSettings.RunOptions, ProtoRunOptions);
-            //controller handle call
+            Controller.Run(ProtoRunOptions);
         } 
 
         if (command == "start") {
             NMessages::TStartOptions ProtoStartOptions;
             ProtoStartOptions = TConverter::ConvertStartOptions(mainSettings.StartOptions, ProtoStartOptions);
-            //controller handle call
+            Controller.Start(ProtoStartOptions);
         }
 
         if (command == "stop") {
             NMessages::TStopOptions ProtoStopOptions;
             ProtoStopOptions = TConverter::ConvertStopOptions(mainSettings.StopOptions, ProtoStopOptions);
-            //controller handle call
+            Controller.Stop(ProtoStopOptions);
         }
 
         if (command == "ps") {
             NMessages::TPsOptions ProtoPsOptions;
             ProtoPsOptions = TConverter::ConvertPsOptions(mainSettings.PsOptions, ProtoPsOptions);
-            //controller handle call
+            Controller.Ps(ProtoPsOptions);
         }
 
         if (command == "rm") {
             NMessages::TRmOptions ProtoRmOptions;
             ProtoRmOptions = TConverter::ConvertRmOptions(mainSettings.RmOptions, ProtoRmOptions);
-            //controller handle call
+            Controller.Rm(ProtoRmOptions);
         }
 
         if (command == "exec") {
             NMessages::TExecOptions ProtoExecOptions;
             ProtoExecOptions = TConverter::ConvertExecOptions(mainSettings.ExecOptions, ProtoExecOptions);
-            //controller handle call
+            Controller.Exec(ProtoExecOptions);
         }
 
         if (command == "attach") {

--- a/dasboot/cli/cli.hpp
+++ b/dasboot/cli/cli.hpp
@@ -97,7 +97,6 @@ namespace NCli {
 
     class TConverter {
     public:
-        static void SendMainSettings(const TMainSettings& mainSettings, const std::string& command);
         static NMessages::TRunOptions ConvertRunOptions(const NCli::TRunOptions& options, NMessages::TRunOptions& protoOptions);
         static NMessages::TBuildOptions ConvertBuildOptions(const NCli::TBuildOptions& options, NMessages::TBuildOptions& protoOptions);
         static NMessages::TStartOptions ConvertStartOptions(const NCli::TStartOptions& options, NMessages::TStartOptions& protoOptions);
@@ -106,6 +105,14 @@ namespace NCli {
         static NMessages::TRmOptions ConvertRmOptions(const NCli::TRmOptions& options, NMessages::TRmOptions& protoOptions);
         static NMessages::TExecOptions ConvertExecOptions(const NCli::TExecOptions& options, NMessages::TExecOptions& protoOptions);
         static NMessages::TAttachOptions ConvertAttachOptions(const NCli::TAttachOptions& options, NMessages::TAttachOptions& protoOptions);
+    };
+
+    class TSender {
+    private:
+        NController::TController Controller;
+    public:
+        TSender(std::string adress);
+        void SendMainSettings(const TMainSettings& mainSettings, const std::string& command);
     };
 
     std::unique_ptr<TParser> MakeDasbootParser(TMainSettings& settings);

--- a/dasboot/controller/CMakeLists.txt
+++ b/dasboot/controller/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(controller ${SOURCES} ${HEADERS})
 apply_compile_flags(controller)
 target_link_libraries(controller PUBLIC ProtobufMessages)
 add_dependencies(controller ProtobufMessages)
+target_link_libraries(controller PRIVATE libzmq)
 
 # tests:
 
@@ -18,6 +19,8 @@ target_link_libraries(
     GTest::gtest
     controller
     ProtobufMessages
+    libzmq
+    cli
 )
 
 gtest_discover_tests(controller_ut)

--- a/dasboot/controller/CMakeLists.txt
+++ b/dasboot/controller/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(controller ${SOURCES} ${HEADERS})
 apply_compile_flags(controller)
 target_link_libraries(controller PUBLIC ProtobufMessages)
 add_dependencies(controller ProtobufMessages)
-target_link_libraries(controller PRIVATE libzmq)
+target_link_libraries(controller PUBLIC cppzmq)
 
 # tests:
 
@@ -19,7 +19,7 @@ target_link_libraries(
     GTest::gtest
     controller
     ProtobufMessages
-    libzmq
+    cppzmq
     cli
 )
 

--- a/dasboot/controller/controller.cpp
+++ b/dasboot/controller/controller.cpp
@@ -2,5 +2,79 @@
 
 namespace NController {
 
+    void TController::Run(const NMessages::TRunOptions& RunOptions) {
+        std::string message;
+        RunOptions.SerializeToString(&message);
+        StartConnection();
+        WriteToDaemon(message);
+    }
+
+    void TController::Build(const NMessages::TBuildOptions& BuildOptions) {
+        std::string message;
+        BuildOptions.SerializeToString(&message);
+        StartConnection();
+        WriteToDaemon(message);
+    }
+
+    void TController::Start(const NMessages::TStartOptions& StartOptions) {
+        std::string message;
+        StartOptions.SerializeToString(&message);
+        StartConnection();
+        WriteToDaemon(message);
+    }
+
+    void TController::Stop(const NMessages::TStopOptions& StopOptions) {
+        std::string message;
+        StopOptions.SerializeToString(&message);
+        StartConnection();
+        WriteToDaemon(message);
+    }
+
+    void TController::Ps(const NMessages::TPsOptions& PsOptions) {
+        std::string message;
+        PsOptions.SerializeToString(&message);
+        StartConnection();
+        WriteToDaemon(message);
+    }
+
+    void TController::Exec(const NMessages::TExecOptions& ExecOptions) {
+        std::string message;
+        ExecOptions.SerializeToString(&message);
+        StartConnection();
+        WriteToDaemon(message);
+    }
+
+    void TController::Rm(const NMessages::TRmOptions& RmOptions) {
+        std::string message;
+        RmOptions.SerializeToString(&message);
+        StartConnection();
+        WriteToDaemon(message);
+    }
+
+
+    TController::TController(const std::string& adress)
+    :
+    Context(1), Socket(Context, ZMQ_REQ),  Adress(adress)
+    {}
+
+
+    void TController::StartConnection() {
+        Socket.connect(Adress);
+    }
+
+    void TController::WriteToDaemon(std::string& message) {
+        Socket.send(zmq::buffer(message), zmq::send_flags::none);
+    }
+
+    std::string TController::ReadFromDaemon() {
+        zmq::message_t message;
+        auto result = Socket.recv(message);
+        if (!result) {
+            throw std::runtime_error("Failed to receive message");
+            return "";
+        }
+        return std::string(static_cast<char*>(message.data()), message.size());
+    }
+
 
 } // namespace NController

--- a/dasboot/controller/controller.hpp
+++ b/dasboot/controller/controller.hpp
@@ -4,49 +4,36 @@
 #include <string>
 #include <optional>
 #include <stdlib.h>
+#include <zmq.hpp>
 
+// #include <dasboot/cli/cli.hpp>
 #include <messages.pb.h>
 
-#define TZeroMQSocket int // TODO: VoidZeroNull0, temporary solution
+// #define TZeroMQSocket int // TODO: VoidZeroNull0, temporary solution
 
 namespace NController {
     using std::string;
 
-    /* Used for default configurations retrievment: */
-    class TGlobalConfig final {
-        public:
-            string GetDaemonPort();
-
-            string GetDefaultConfigPath();
-    };
-
     class TController final {
         private:
-            const TGlobalConfig GlobalConfig;
-            TZeroMQSocket DaemonSocket;
+            zmq::context_t Context;
+            zmq::socket_t Socket;
+            std::string Adress;
 
         public:
-            TController(TGlobalConfig& globalConfig) : GlobalConfig(globalConfig) {};
+            TController(const std::string& adress);
 
-            bool WriteToDaemon();
-            bool ReadFromDaemon();
+            void StartConnection();
+            void WriteToDaemon(std::string& message);
+            std::string ReadFromDaemon();
 
-            // These ask globalConfig:
-            bool Version();
-            bool Info();
-            bool Help();
-            bool CommandHelp(const std::string command);
-
-            // These work with Daemon:
-            bool Build();
-
-            bool Start();
-
-            bool Stop();
-            bool Remove();
-
-            bool Execute();
-
-            bool List();
-    };
+            // command handlers
+            void Run(const NMessages::TRunOptions& RunOptions);
+            void Build(const NMessages::TBuildOptions& BuildOptions);
+            void Start(const NMessages::TStartOptions& StartOptions);
+            void Stop(const NMessages::TStopOptions& StopOptions);
+            void Ps(const NMessages::TPsOptions& PsOptions);
+            void Exec(const NMessages::TExecOptions& ExecOptions);
+            void Rm(const NMessages::TRmOptions& RmOptions);
+   };
 };

--- a/dasboot/controller/controller.hpp
+++ b/dasboot/controller/controller.hpp
@@ -6,10 +6,7 @@
 #include <stdlib.h>
 #include <zmq.hpp>
 
-// #include <dasboot/cli/cli.hpp>
 #include <messages.pb.h>
-
-// #define TZeroMQSocket int // TODO: VoidZeroNull0, temporary solution
 
 namespace NController {
     using std::string;

--- a/dasboot/controller/controller_ut.cpp
+++ b/dasboot/controller/controller_ut.cpp
@@ -5,25 +5,23 @@
 #include <messages.pb.h>
 
 using string = std::string;
-class TServer final {
+class TTestServer final {
     private:
         zmq::context_t Context;
         zmq::socket_t Socket;
         string Adress;
 
     public:
-        explicit TServer(const string& adress)
+        explicit TTestServer(const string& adress)
         : Context(1), Socket(Context, ZMQ_REP), Adress(adress) 
-        {}
-
-        void StartConnection() {
-            Socket.bind(Adress);
+        {
+            Socket.bind(Adress); //Start connection
         }
         
         string GetMessage() {
             zmq::message_t message_1;
 
-            [[maybe_unused]] auto result = Socket.recv(message_1, zmq::recv_flags::none);
+            (void)Socket.recv(message_1, zmq::recv_flags::none);
             string request_str(static_cast<char*>(message_1.data()), message_1.size());
             return request_str;
         }
@@ -35,10 +33,27 @@ class TServer final {
 };
 
 namespace {
-    TServer server("ipc:///tmp/testsocket");
+    TTestServer server("ipc:///tmp/testsocket");
 } // anonymous namespace
 
-TEST(ControllerUt, CommandBuild0) {
+TEST(ControllerUt, CommandRun) {
+    NMessages::TRunOptions ExpectedRunOptions;
+    string ExpectedString;
+    ExpectedRunOptions.set_name("Container_name");
+    ExpectedRunOptions.SerializeToString(&ExpectedString);
+
+    NCli::TMainSettings settings;
+    settings.RunOptions.Name = "Container_name";
+    string command = "run";
+    NCli::TSender Sender("ipc:///tmp/testsocket"); 
+    Sender.SendMainSettings(settings, command);
+    string ServerMessage = server.GetMessage();
+    server.SendMessage();
+    
+    ASSERT_EQ(ServerMessage, ExpectedString);
+}
+
+TEST(ControllerUt, CommandBuild) {
     NMessages::TBuildOptions ExpectedBuildOptions;
     string ExpectedString;
     ExpectedBuildOptions.set_name("Container_name");
@@ -57,16 +72,13 @@ TEST(ControllerUt, CommandBuild0) {
     ASSERT_EQ(ServerMessage, ExpectedString);
 }
 
-
-TEST(ControllerUt, CommandBuild1) {
-    NMessages::TBuildOptions ExpectedBuildOptions;
+TEST(ControllerUt, CommandStart) {
+    NMessages::TStartOptions ExpectedStartOptions;
     string ExpectedString;
-    ExpectedBuildOptions.set_name("Container");
-    ExpectedBuildOptions.SerializeToString(&ExpectedString);
+    ExpectedStartOptions.SerializeToString(&ExpectedString);
 
     NCli::TMainSettings settings;
-    settings.BuildOptions.Name = "Container";
-    string command = "build";
+    string command = "start";
     NCli::TSender Sender("ipc:///tmp/testsocket"); 
     Sender.SendMainSettings(settings, command);
     string ServerMessage = server.GetMessage();
@@ -75,9 +87,97 @@ TEST(ControllerUt, CommandBuild1) {
     ASSERT_EQ(ServerMessage, ExpectedString);
 }
 
+TEST(ControllerUt, CommandStop) {
+    NMessages::TStopOptions ExpectedStopOptions;
+    string ExpectedString;
+    ExpectedStopOptions.set_name("Container_name");
+    ExpectedStopOptions.SerializeToString(&ExpectedString);
+
+    NCli::TMainSettings settings;
+    settings.StopOptions.Name = "Container_name";
+    string command = "stop";
+    NCli::TSender Sender("ipc:///tmp/testsocket"); 
+    Sender.SendMainSettings(settings, command);
+    string ServerMessage = server.GetMessage();
+    server.SendMessage();
+
+    ASSERT_EQ(ServerMessage, ExpectedString);
+}
+
+TEST(ControllerUt, CommandPs) {
+    NMessages::TPsOptions ExpectedPsOptions;
+    string ExpectedString;
+    ExpectedPsOptions.set_show_all(true);
+    ExpectedPsOptions.SerializeToString(&ExpectedString);
+
+    NCli::TMainSettings settings;
+    settings.PsOptions.ShowAll = true;
+    string command = "ps";
+    NCli::TSender Sender("ipc:///tmp/testsocket"); 
+    Sender.SendMainSettings(settings, command);
+    string ServerMessage = server.GetMessage();
+    server.SendMessage();
+
+    ASSERT_EQ(ServerMessage, ExpectedString);
+}
+
+TEST(ControllerUt, CommandRm) {
+    NMessages::TRmOptions ExpectedRmOptions;
+    string ExpectedString;
+    ExpectedRmOptions.set_id("Container_id");
+    ExpectedRmOptions.SerializeToString(&ExpectedString);
+
+    NCli::TMainSettings settings;
+    settings.RmOptions.Id = "Container_id";
+    string command = "rm";
+    NCli::TSender Sender("ipc:///tmp/testsocket"); 
+    Sender.SendMainSettings(settings, command);
+    string ServerMessage = server.GetMessage();
+    server.SendMessage();
+
+    ASSERT_EQ(ServerMessage, ExpectedString);
+}
+
+TEST(ControllerUt, CommandExec) {
+    NMessages::TExecOptions ExpectedExecOptions;
+    string ExpectedString;
+    ExpectedExecOptions.set_name("Container_name");
+    ExpectedExecOptions.set_id("Container_id");
+    ExpectedExecOptions.set_detach(true);
+    ExpectedExecOptions.SerializeToString(&ExpectedString);
+
+    NCli::TMainSettings settings;
+    settings.ExecOptions.Name = "Container_name";
+    settings.ExecOptions.Id = "Container_id";
+    settings.ExecOptions.Detach = true;
+    string command = "exec";
+    NCli::TSender Sender("ipc:///tmp/testsocket"); 
+    Sender.SendMainSettings(settings, command);
+    string ServerMessage = server.GetMessage();
+    server.SendMessage();
+
+    ASSERT_EQ(ServerMessage, ExpectedString);
+}
+
+// TEST(ControllerUt, CommandBuild1) {
+//     NMessages::TBuildOptions ExpectedBuildOptions;
+//     string ExpectedString;
+//     ExpectedBuildOptions.set_name("Container");
+//     ExpectedBuildOptions.SerializeToString(&ExpectedString);
+
+//     NCli::TMainSettings settings;
+//     settings.BuildOptions.Name = "Container";
+//     string command = "build";
+//     NCli::TSender Sender("ipc:///tmp/testsocket"); 
+//     Sender.SendMainSettings(settings, command);
+//     string ServerMessage = server.GetMessage();
+//     server.SendMessage();
+
+//     ASSERT_EQ(ServerMessage, ExpectedString);
+// }
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    server.StartConnection();
     auto result = RUN_ALL_TESTS();
     return result;
 }

--- a/dasboot/controller/controller_ut.cpp
+++ b/dasboot/controller/controller_ut.cpp
@@ -159,22 +159,6 @@ TEST(ControllerUt, CommandExec) {
     ASSERT_EQ(ServerMessage, ExpectedString);
 }
 
-// TEST(ControllerUt, CommandBuild1) {
-//     NMessages::TBuildOptions ExpectedBuildOptions;
-//     string ExpectedString;
-//     ExpectedBuildOptions.set_name("Container");
-//     ExpectedBuildOptions.SerializeToString(&ExpectedString);
-
-//     NCli::TMainSettings settings;
-//     settings.BuildOptions.Name = "Container";
-//     string command = "build";
-//     NCli::TSender Sender("ipc:///tmp/testsocket"); 
-//     Sender.SendMainSettings(settings, command);
-//     string ServerMessage = server.GetMessage();
-//     server.SendMessage();
-
-//     ASSERT_EQ(ServerMessage, ExpectedString);
-// }
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/dasboot/controller/controller_ut.cpp
+++ b/dasboot/controller/controller_ut.cpp
@@ -1,9 +1,83 @@
 #include <gtest/gtest.h>
 
 #include <dasboot/controller/controller.hpp>
+#include <dasboot/cli/cli.hpp>
+#include <messages.pb.h>
+
+using string = std::string;
+class TServer final {
+    private:
+        zmq::context_t Context;
+        zmq::socket_t Socket;
+        string Adress;
+
+    public:
+        explicit TServer(const string& adress)
+        : Context(1), Socket(Context, ZMQ_REP), Adress(adress) 
+        {}
+
+        void StartConnection() {
+            Socket.bind(Adress);
+        }
+        
+        string GetMessage() {
+            zmq::message_t message_1;
+
+            [[maybe_unused]] auto result = Socket.recv(message_1, zmq::recv_flags::none);
+            string request_str(static_cast<char*>(message_1.data()), message_1.size());
+            return request_str;
+        }
+
+        void SendMessage() {
+            zmq::message_t reply("OK", 2);
+            Socket.send(reply, zmq::send_flags::none);
+        }
+};
+
+namespace {
+    TServer server("ipc:///tmp/testsocket");
+} // anonymous namespace
+
+TEST(ControllerUt, CommandBuild0) {
+    NMessages::TBuildOptions ExpectedBuildOptions;
+    string ExpectedString;
+    ExpectedBuildOptions.set_name("Container_name");
+    ExpectedBuildOptions.set_pathtodasbootfile("path/to/file");
+    ExpectedBuildOptions.SerializeToString(&ExpectedString);
+
+    NCli::TMainSettings settings;
+    settings.BuildOptions.Name = "Container_name";
+    settings.BuildOptions.PathToDasbootFile = "path/to/file";
+    string command = "build";
+    NCli::TSender Sender("ipc:///tmp/testsocket"); 
+    Sender.SendMainSettings(settings, command);
+    string ServerMessage = server.GetMessage();
+    server.SendMessage();
+    
+    ASSERT_EQ(ServerMessage, ExpectedString);
+}
+
+
+TEST(ControllerUt, CommandBuild1) {
+    NMessages::TBuildOptions ExpectedBuildOptions;
+    string ExpectedString;
+    ExpectedBuildOptions.set_name("Container");
+    ExpectedBuildOptions.SerializeToString(&ExpectedString);
+
+    NCli::TMainSettings settings;
+    settings.BuildOptions.Name = "Container";
+    string command = "build";
+    NCli::TSender Sender("ipc:///tmp/testsocket"); 
+    Sender.SendMainSettings(settings, command);
+    string ServerMessage = server.GetMessage();
+    server.SendMessage();
+
+    ASSERT_EQ(ServerMessage, ExpectedString);
+}
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
+    server.StartConnection();
     auto result = RUN_ALL_TESTS();
     return result;
 }


### PR DESCRIPTION
Implemented TController. It contains command handlers that serialize protobuf messages and send them to the daemon.
Additionally, this commit extends the TSender class, which connects the CLI and the Controller